### PR TITLE
Only redraw VU and bars when needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In the [`settings.inc`](settings.inc) file, a number of symbols are defined that
 |SERIAL|0 or 1|Yes|Set to 1 to read visualisation data from the user port
 |TIMING|0 or 1|Yes|Set to 1 to show timing information concerning the drawing of spectrum analyzer updates. Only supported on the C64 and has not been used for a while, so may need some attention to make it work.|
 
-Note that the PET and C64 symbols are not set by default. The reason is that the assembly target is a prime candidate to be set via the command line. Also, on the PET only the demo mode (see below) currently works. The reason is that we're still looking for suitable serial code for audio data ingestion on the PET.
+Note that the PET and C64 symbols are not set by default. The reason is that the assembly target is a prime candidate to be set via the command line.
 
 This repository's code targets the ca65 assembler and cl65 linker that are part of the [cc65](https://cc65.github.io/) GitHub project. You will need a fairly recent build of cc65 for assembly of this repository's contents to work. If you receive errors about the .literal mnemonic, this is the likely reason.
 

--- a/petrock.asm
+++ b/petrock.asm
@@ -68,6 +68,7 @@ ScratchStart:
     Peaks:           .res  NUM_BANDS      ; Peak Data for current frame
     NextStyle:       .res  1              ; The next style we will pick
     CharDefs:        .res  VISUALDEF_SIZE ; Storage for the visualDef currently in use
+    RedrawFlag:      .res  1              ; Flag to redraw screen
     DemoMode:        .res  1              ; Demo mode enabled
 .if C64         ; Color's only relevant on the C64
     CurSchemeIndex:  .res  1              ; Current band color scheme index
@@ -86,7 +87,6 @@ ScratchStart:
     SerialBufPos:    .res  1              ; Current index into serial buffer
     SerialBuf:       .res  PACKET_LENGTH  ; Serial buffer for: "DP" + 1 byte vu + 8 PeakBytes
     SerialBufLen = *-SerialBuf            ; Length of Serial Buffer
-    HeardPacket:     .res  1              ; Flag for receipt of complete packet
   .if C64
 .include "serial/c64/vars.s"
   .elseif PET
@@ -226,7 +226,7 @@ drawLoop:
 .endif
 
 @donedata:      lda DemoMode          ; Load demo data if demo mode is on
-                beq @nodemo
+                beq @redraw
                 jsr FillPeaks
                 ldx #$08
                 ldy #$ff
@@ -234,31 +234,34 @@ drawLoop:
                 bne @delay
                 dex
                 bne @delay
-                beq @dovu
 
-@nodemo:        
-.if SERIAL
-                lda HeardPacket
-                beq drawLoop          ; We didn't get a complete packet yet, so no point in drawing anything
+@redraw:        lda RedrawFlag
+                beq @afterdraw        ; We didn't get a complete packet yet, so no point in drawing anything
                 lda #0 
-                sta HeardPacket       ; Acknowledge packet
-.endif
-@dovu:          jsr DrawVU            ; Draw the VU bar at the top of the screen
+                sta RedrawFlag        ; Acknowledge packet
+
+                jsr DrawVU            ; Draw the VU bar at the top of the screen
 
 .if TIMING && C64                     ; If 'TIMING' is defined we turn the border
                 lda #LIGHT_GREY       ;  color to different colors at particular
                 sta VIC_BORDERCOLOR   ;  places in the draw code to help see how
 .endif                                ;  long various parts of it are taking.
 
-drawAllBands:   ldx #NUM_BANDS - 1    ; Draw each of the bands in reverse order
+                ldx #NUM_BANDS - 1    ; Draw each of the bands in reverse order
 :
                 lda Peaks, x          ; X = band numner, A = value
                 jsr DrawBand
                 dex
                 bpl :-
-                ; Check to see its time to scroll the color memory
+
+.if SERIAL
+                lda #'*'              ; Send a * back to the host
+                jsr PutSerialChar
+.endif
 
 .if TIMING && C64
+                ; Check to see its time to scroll the color memory
+
                 lda #BLACK
                 sta VIC_BORDERCOLOR
 :               bit RASTHI
@@ -291,11 +294,9 @@ drawAllBands:   ldx #NUM_BANDS - 1    ; Draw each of the bands in reverse order
                 jsr CHROUT
 .endif          ; TIMING && C64
 
-                jsr CheckTextTimer
+@afterdraw:     jsr CheckTextTimer
 
 .if SERIAL
-                lda #'*'              ; Send a * back to the host
-                jsr PutSerialChar
                 jsr GetKeyboardChar   ; Get a character from the serial driver's keyboard handler
 .else
                 jsr GETIN             ; No serial, use regular GETIN routine
@@ -487,7 +488,7 @@ GotSerial:      ldy SerialBufPos
 :               cpy SerialBufPos          ; Are we in the right char pos for it?
                 beq :+                    ;  Yep - Process packet
                 ldy #0                    ;  Nope - Restart filling buffer
-                sta SerialBufPos
+                sty SerialBufPos
                 beq @done
 
 :               jsr GotSerialPacket
@@ -543,7 +544,7 @@ GotSerialPacket:
                 bne :-                    ; Repeat until we have
 
                 lda #1
-                sta HeardPacket
+                sta RedrawFlag            ; Time to redraw!
                 rts
 
 .endif          ; SERIAL
@@ -600,9 +601,13 @@ FillPeaks:
                 lda (zptmpB), y
                 sta VU
 
+                lda #1
+                sta RedrawFlag        ; Time to redraw!
+
                 inc DataIndex         ; Inc DataIndex - Assumes wrap, so if you
                                       ;   have exacly 256 bytes, you'd need to
                                       ;   check and fix that here
+
                 pla
                 tax
                 pla
@@ -622,6 +627,9 @@ InitVariables:  ldx #ScratchEnd-ScratchStart
                 dex
                 cpx #$ff
                 bne :-
+
+                lda #1
+                sta RedrawFlag
 
                 rts
 
@@ -643,6 +651,9 @@ SwitchDemoMode: lda DemoMode          ; Toggle demo mode bit
                 bpl :-
 
                 sta VU
+
+                lda #1
+                sta RedrawFlag        ; Force redraw
 
                 ldx #<DemoOffText     ; Tell user what just happened
                 ldy #>DemoOffText

--- a/serial/pet/driver.s
+++ b/serial/pet/driver.s
@@ -243,7 +243,7 @@ SendBit:
                 lda #ST_READY
                 sta TxState
                 rts
-@databit:  ; Send data bit
+@databit:       ; Send data bit
                 lda #0
                 ror TxCurByte         ; Rotate current bit into carry
                 rol                   ; Place into A


### PR DESCRIPTION
Redraw is needed when:

- A "well-formed" packet is received via serial
- A frame of demo data has been loaded
- Resetting VU and bars is appropriate